### PR TITLE
Social share footer

### DIFF
--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.hlp
@@ -64,6 +64,6 @@
   {ts}Social Sharing{/ts}
 {/htxt}
 {htxt id="id-is_share"}
-<p>{ts}When enabled, links allowing people to share this online contribution page with their social network will be displayed (e.g. Facebook "Like", Google+, and Twitter).{/ts}</p>
+<p>{ts}When enabled, links helping people share this online contribution page with their social network will be displayed (e.g. Facebook, Twitter, Linked In and Email).{/ts}</p>
 <p>{ts}Social media links will be included on the Contribution Thank-you page, Tell-a-Friend page (if enabled), and in contribution receipt emails.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Contribute/Form/ContributionPage/Settings.hlp
+++ b/templates/CRM/Contribute/Form/ContributionPage/Settings.hlp
@@ -64,6 +64,6 @@
   {ts}Social Sharing{/ts}
 {/htxt}
 {htxt id="id-is_share"}
-<p>{ts}When enabled, links helping people share this online contribution page with their social network will be displayed (e.g. Facebook, Twitter, Linked In and Email).{/ts}</p>
+<p>{ts}When enabled, links helping people share this online contribution page with their social network will be displayed (e.g. Facebook, Twitter, LinkedIn and email).{/ts}</p>
 <p>{ts}Social media links will be included on the Contribution Thank-you page, Tell-a-Friend page (if enabled), and in contribution receipt emails.{/ts}</p>
 {/htxt}

--- a/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
+++ b/templates/CRM/Event/Form/ManageEvent/EventInfo.hlp
@@ -106,6 +106,6 @@
   {ts}Social Sharing{/ts}
 {/htxt}
 {htxt id="id-is_share"}
-<p>{ts}When enabled, links allowing people to share this event with their social network will be displayed (e.g. Facebook "Like", Google+, and Twitter).{/ts}</p>
+<p>{ts}When enabled, links helping people share this event with their social network will be displayed (e.g. Facebook, Twitter, LinkedIn and email).{/ts}</p>
 <p>{ts}Social media links will be included on the Event Info page, Thank-you page, Tell-a-Friend page (if enabled), and in event confirmation emails.{/ts}</p>
 {/htxt}

--- a/templates/CRM/common/SocialNetwork.tpl
+++ b/templates/CRM/common/SocialNetwork.tpl
@@ -7,56 +7,28 @@
  | and copyright information, see https://civicrm.org/licensing       |
  +--------------------------------------------------------------------+
 *}
-{* Adds social networking buttons (Facebook like, Twitter tweet, Google +1, LinkedIn) to public pages (online contributions, event info) *}
+{* Adds social networking buttons (Facebook, Twitter, LinkedIn, email) to public pages (online contributions, event info) *}
 
-<div class="crm-section crm-socialnetwork help">
-    <h3 class="nobackground">{ts}Help spread the word{/ts}</h3>
-    <div class="description">
-        {ts}Please help us and let your friends, colleagues and followers know about our page{/ts}{if $title}:
-        <span class="bold"><a href="{$pageURL}">{$title}</a></span>
-        {else}.{/if}
-    </div>
-    <div class="crm-fb-tweet-buttons">
-        {if $emailMode eq true}
-            {*use images for email*}
-            <a href="https://twitter.com/share?url={$url|escape:'url'}&amp;text={$title}" id="crm_tweet">
-                <img title="Twitter Tweet Button" src="{$config->userFrameworkResourceURL|replace:'https://':'http://'}/i/tweet.png" width="55px" height="20px"  alt="Tweet Button">
-            </a>
-            <a href="https://www.facebook.com/plugins/like.php?href={$url}" target="_blank">
-                <img title="Facebook Like Button" src="{$config->userFrameworkResourceURL|replace:'https://':'http://'}/i/fblike.png" alt="Facebook Button" />
-            </a>
-        {else}
-            {*use advanced buttons for pages*}
-            <div class="label">
-                <iframe allowtransparency="true" frameborder="0" scrolling="no"
-                src="https://platform.twitter.com/widgets/tweet_button.html?text={$title}&amp;url={$url|escape:'url'}"
-                style="width:100px; height:20px;">
-                </iframe>
-            </div>
-            <div class="label" style="width:300px;">
-                <iframe src="https://www.facebook.com/plugins/like.php?app_id=240719639306341&amp;href={$url|escape:'url'}&amp;send=false&amp;layout=standard&amp;show_faces=false&amp;action=like&amp;colorscheme=light" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:300px; height:30px;" allowTransparency="true">
-                </iframe>
-            </div>
-            <div class="label">
-              <script src="https://platform.linkedin.com/in.js" type="text/javascript"></script>
-              <script type="IN/Share" data-url={$url} data-counter="right"></script>
-            </div>
-        {/if}
-    </div>
-    {if $pageURL}
-      {if $emailMode neq true}
-        <br/>
-      {/if}
-      <br/>
-      <div class="clear"></div>
-      <div>
-        <span class="bold">{ts}You can also share the below link in an email or on your website.{/ts}</span>
-        <br/>
-        <a href="{$pageURL}">{$pageURL}</a>
-      </div>
+<div class="crm-section crm-socialnetwork alert alert-success status crm-ok" role="alert">
+    <h2>{ts}Help spread the word{/ts}</h2>
+    <p>{ts}Please help us and let your friends, colleagues and followers know about our page{/ts}{if $title}: <strong><a href="{$pageURL}">{$title}</a></strong>{else}.{/if}</p>
+    {if $emailMode eq true}
+        <a href="https://twitter.com/share?url={$url|escape:'url'}&amp;text={$title}" class="btn btn-default" role="button" target="_blank">{ts}Tweet{/ts}</a>
+        <a href="https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}" target="_blank" class="btn btn-default" role="button">{ts}Share on Facebook{/ts}</a>
+        <a href="ttps://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title}" target="_blank" rel="noopener" class="btn btn-default">{ts}Share on LinkedIn{/ts}</a>
     {else}
-      <div class="clear"></div>
+    	<button onclick="window.open('https://twitter.com/share?url={$url|escape:'url'}&amp;text={$title}','_blank')" type="button" class="btn btn-default"><i aria-hidden="true" class="crm-i fa-twitter"></i>&nbsp;&nbsp;{ts}Tweet{/ts}</button>
+        <button onclick="window.open('https://facebook.com/sharer/sharer.php?u={$url|escape:'url'}','_blank')" type="button" class="btn btn-default" role="button"><i aria-hidden="true" class="crm-i fa-facebook"></i>&nbsp;&nbsp;{ts}Share on Facebook{/ts}</button>
+        <button onclick="window.open('https://www.linkedin.com/shareArticle?mini=true&amp;url={$url|escape:'url'}&amp;title={$title}','_blank')" type="button" rel="noopener" class="btn btn-default"><i aria-hidden="true" class="crm-i fa-linkedin"></i>&nbsp;&nbsp;{ts}Share on LinkedIn{/ts}</button>
+        <button onclick="window.open('mailto:?subject={$title}.&amp;body={$url|escape:'url'}','_self')" type="button" rel="noopener" class="btn btn-default"><i aria-hidden="true" class="crm-i fa-envelope"></i>&nbsp;&nbsp;{ts}Email{/ts}</button>
+        {/if}
+    {if $pageURL}
+    	{if $emailMode neq true}
+        <br/>
+		{/if}
+    <br/>
+    <p><strong>{ts}You can also share the below link in an email or on your website:{/ts}</strong><br />
+    <a href="{$pageURL}">{$pageURL}</a></p>
+    {else}
     {/if}
 </div>
-
-


### PR DESCRIPTION
Overview
----------------------------------------
Updates the social media sharing footer:
 - replaces embed scripts with direct links
 - adds email share button
 - adds Bootstrap classes
 - uses <button> for visual fallback in absence of Bootstrap
 - designed to work visually in four front-end scenarios: no Bootstrap front-end theme, Bootstrap front-end theme, no CiviCRM front-end CSS but Bootstrap, no CiviCRM front-end CSS and no Bootstrap.

Before
----------------------------------------
The footer will look the same in each of the four scenarios above

https://stackoverflow.com/questions/9120539/facebook-share-link-without-javascript

After
----------------------------------------
no Bootstrap front-end theme:

<img width="726" alt="image" src="https://user-images.githubusercontent.com/1175967/97465989-e70f2f00-1942-11eb-9c3d-87bf12d240e4.png">

Bootstrap front-end theme:

<img width="697" alt="image" src="https://user-images.githubusercontent.com/1175967/97466075-fd1cef80-1942-11eb-9af6-2a133937fc7a.png">

no CiviCRM front-end CSS but Bootstrap:

<img width="705" alt="image" src="https://user-images.githubusercontent.com/1175967/97466129-0c9c3880-1943-11eb-88d2-5065e3a35d1f.png">

no CiviCRM front-end CSS and no Bootstrap:

<img width="721" alt="image" src="https://user-images.githubusercontent.com/1175967/97466146-12921980-1943-11eb-96f2-bc5569abb82b.png">


Technical Details
----------------------------------------
This footer appears at the bottom of contribution and event pages and also is included in [a few email] templates(https://github.com/civicrm/civicrm-core/search?p=1&q=%24emailMode). 

The markup for email code is enabled under `{if $emailMode eq true}` and uses `<a>` with Bootstrap css classes (not Civi button classes).

For the contribution/event page footers, `<button>` is used, with an onclick behaviour, in order to provide button styling independent of CiviCRM.css and Bootstrap.css if needed.

The Facebook share code is based on the same code used by [ShareButtons.io](https://github.com/mxstbr/sharingbuttons.io) and recommended [here](https://stackoverflow.com/questions/9120539/facebook-share-link-without-javascript) – however when testing this today it didn't work, so I'm not sure if Facebook has disabled this method, or there is a temporary issue.

Comments
----------------------------------------
If the Facebook URL share method has been disabled, rather than a temporary issue, then this PR is a regression. 

Testing on email is needed.