### PR TITLE
Update CustomDataView.tpl

### DIFF
--- a/templates/CRM/Contact/Page/View/CustomDataView.tpl
+++ b/templates/CRM/Contact/Page/View/CustomDataView.tpl
@@ -14,17 +14,17 @@
   {assign var="count" value=$customGroupCount%2}
   {if ($count eq $side) or $skipTitle}
     {foreach from=$customValues item=cd_edit key=cvID}
-      <div class="customFieldGroup crm-collapsible{if !empty($cd_edit.collapse_display)} collapsed{/if} ui-corner-all {$cd_edit.name} crm-custom-set-block-{$customGroupId}">
-        <div class="collapsible-title">
+      <details class="customFieldGroup crm-accordion-wrapper ui-corner-all {$cd_edit.name} crm-custom-set-block-{$customGroupId}" {if !empty($cd_edit.collapse_display)} open{/if}>
+        <summary class="crm-accordion-header crm-master-accordion-header">
           {$cd_edit.title}
-        </div>
+        </summary>
         {if $cvID eq 0}
           {assign var='cvID' value='-1'}
         {/if}
         <div class="crm-summary-block" id="custom-set-block-{$customGroupId}-{$cvID}">
           {include file="CRM/Contact/Page/View/CustomDataFieldView.tpl" customGroupId=$customGroupId customRecId=$cvID cgcount=$cgcount}
         </div>
-      </div>
+      </details>
       {assign var="cgcount" value=$cgcount+1}
     {/foreach}
   {/if}


### PR DESCRIPTION
Makes the contact dashboard accordions for custom fields accessible using the <details><summary> pattern. Has the added advantage of replacing a less common Civi accordion pattern `.crm-collapsible` ([accordion3 in ThemeTest](https://lab.civicrm.org/extensions/themetest/-/blob/master/ang/themetest/snippets/accordion3.html?ref_type=heads)) - but achieves this by changing the class name.

Before
----------------------------------------
Custom field accordions aren't keyboard controllable
<img width="1441" alt="image" src="https://github.com/vingle/civicrm-core/assets/1175967/b2914829-271f-40fd-8298-962375f288fd">

After
----------------------------------------
They are:
<img width="1439" alt="image" src="https://github.com/vingle/civicrm-core/assets/1175967/c4172b8d-8b16-45e5-8c55-809e9ee2204c">

Technical Details
----------------------------------------
To make this match it's appearance in Grenwich, the class `.crm-master-accordion-header` is added to summary to make it transparent (as used [accordion8](https://lab.civicrm.org/extensions/themetest/-/blob/master/ang/themetest/snippets/accordion8.html?ref_type=heads)

Comments
----------------------------------------
Might impact 3rd party themes as it's changed class names, so flagging it in [chat.civicrm.org/theme-maintainers ](https://chat.civicrm.org/civicrm/channels/theme-maintainers). 

Any extension targetting those old classnames would also be impacted, tho can't think of one. 
