### PR TITLE
Ensures Angular accordion isn't applied to <details> tags

### DIFF
--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -59,7 +59,7 @@ af-form {
 .af-collapsible.af-collapsed > .af-title:before {
   content: "\f0da";
 }
-.af-collapsible.af-collapsed > .af-title ~ * {
+div.af-collapsible.af-collapsed > .af-title ~ * {
   display: none !important;
 }
 

--- a/ext/afform/core/ang/afCore.css
+++ b/ext/afform/core/ang/afCore.css
@@ -59,7 +59,8 @@ af-form {
 .af-collapsible.af-collapsed > .af-title:before {
   content: "\f0da";
 }
-div.af-collapsible.af-collapsed > .af-title ~ * {
+div.af-collapsible.af-collapsed > .af-title ~ *,
+fieldset.af-collapsible.af-collapsed > .af-title ~ * {
   display: none !important;
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Following [this](https://github.com/civicrm/civicrm-core/pull/28449) merged PR (written with @coleman),  FormBuilder generates accessible accordions using `<details>`. However any FB displays created before this change might use some old css, which could create non-functioning accordions. In the worst case, the accordion won't 'expand' because this line of css is forcing 'display: none'. 

This PR prevents this _if_ civi is using `<details>`. ie it tells the browser not to hide the accordion body if details are being used with `.af-collapsible`

I don't think this is happening in Civi core, but it might apply to a FormBuilder form made collapsible in the past, that upgrades to 5.69+ – I found this behavior on one of my own test forms.

Before
----------------------------------------
Post 5.69 angular accordions generated via older methods using `.af-collapsible` on a `<details>` element won't expand. 

After
----------------------------------------
They will.

Technical Details
----------------------------------------
The `.af-collapsible` behavior will be preserved on `<div>` containers and `<fieldset>`.

Comments
----------------------------------------
This is about backwards-compatibility for customisations. It shouldn't impact new installs or new SK/FB displays.