### PR TITLE
Adds details resets to Joomla for new accordions

### DIFF
--- a/css/joomla.css
+++ b/css/joomla.css
@@ -22,6 +22,19 @@ body.admin.com_civicrm .subhead-collapse,
 body.admin.com_civicrm.layout-default a[target="_blank"]::before {
   display: none;
 }
+body.admin.com_civicrm .crm-container details { /* Atum J4 reset */
+  background: inherit;
+  border: none;
+  border-radius: inherit;
+  margin: 0;
+  padding: 0;
+}
+body.admin.com_civicrm .crm-container details + details {
+  margin: 0.25rem 0 0;
+}
+body.admin.com_civicrm .crm-container details summary ~ * { /* Atum J4 reset */
+  margin-top: 0; 
+}
 body.admin.com_civicrm.layout-default .crm-dashlet {
   max-width: 60vw;
 }


### PR DESCRIPTION
Overview
----------------------------------------
Joomla 4's Atum theme has default styling for `<details>`. This PR resets that so that Civi Greenwich/custom theme accordion can define the styling.

Before
----------------------------------------
<img width="1052" alt="image" src="https://github.com/vingle/civicrm-core/assets/1175967/4f20e783-b564-422d-a2ae-bf45d1bb582e">

After
----------------------------------------
<img width="1053" alt="image" src="https://github.com/vingle/civicrm-core/assets/1175967/50167030-305c-41b6-aa9a-fdb2a02dcbbc">

Technical Details
----------------------------------------
This is namespaced to target Joomla installs in case this file was ever merged into Civi's main css.

Comments
----------------------------------------
This wasn't picked up in #8 because the Civi markup hadn't changed when that PR was made.