### PR TITLE
Fixes regression: resets text-rendered radio button width

### DIFF
--- a/css/civicrm.css
+++ b/css/civicrm.css
@@ -3341,6 +3341,10 @@ span.crm-select-item-color {
   flex-wrap: wrap;
   gap: var(--gap);
 }
+/* Reset checkbox width when its rendered as text '(x)' in confirmation screens /dev/core/-/issues/5550 */
+.crm-container.crm-public .crm-profile-view .crm-option-label-pair {
+  --checkbox-width: auto;
+}
 /* Override more general styling */
 .crm-container .crm-multiple-checkbox-radio-options :where(input.crm-form-radio,
 input.crm-form-checkbox) + label {


### PR DESCRIPTION
Ref: https://lab.civicrm.org/dev/core/-/issues/5550

Overview
----------------------------------------
The work on multi-column Radio Buttons / Checkboxes (https://github.com/civicrm/civicrm-core/pull/30162) didn't realise that the text rendered output on a Contribution Confirmation Screen uses the same CSS. This fixes this by reseting the width.

Before
----------------------------------------
<img width="188" alt="image" src="https://github.com/user-attachments/assets/20a0a49e-4148-42c2-9ae0-a83eeac58c83">

After
----------------------------------------
<img width="415" alt="image" src="https://github.com/user-attachments/assets/e99d4001-4b17-4bae-a496-deafc5d014c8">

Technical Details
----------------------------------------
The CSS is targeting only front-end CiviCRM via `.crm-container.crm-public` and `.crm-profile-view` which I think is when the content of profiles is outputted. This will therefore [also fix this issue](https://github.com/search?q=repo%3Acivicrm%2Fcivicrm-core%20crm-profile-view&type=code) on the Thank You, Event Registration and Profile View pages - so probably these screens and their related forms need testing.