### PR TITLE
RiverLea: fixes illegible Bootstrap bg region in dark-mode (GL:#112

### DIFF
--- a/ext/riverlea/core/css/_bootstrap.css
+++ b/ext/riverlea/core/css/_bootstrap.css
@@ -1293,7 +1293,7 @@
 #bootstrap-theme .form-control[disabled],
 #bootstrap-theme .form-control[readonly],
 fieldset[disabled] #bootstrap-theme .form-control {
-  background-color: #eee;
+  background-color: var(--crm-c-background2);
   opacity: 1;
 }
 #bootstrap-theme .form-control[disabled],


### PR DESCRIPTION
Bootstrap sets #eee on disabled elements. In dark mode this clashes with the white text on top. Changing to a background colour variable ensures the bg colour inverts along with the text colour.

Ref: https://lab.civicrm.org/extensions/riverlea/-/issues/112 ht @ufundo

Before
----------------------------------------
Minetta light+dark
![image](https://github.com/user-attachments/assets/a1cdf8ef-f1fc-4a14-b8ea-7df82af92399)
![image](https://github.com/user-attachments/assets/9cfe7665-25d0-4188-95ea-60ebac542916)

Walbrook light+dark
![image](https://github.com/user-attachments/assets/ff251eea-ba88-41f1-ba66-b63bc3f75b57)
![image](https://github.com/user-attachments/assets/b743d5b9-9b96-49fa-aa6e-f75c161d6693)

After
----------------------------------------
Minetta light+dark
![image](https://github.com/user-attachments/assets/f2fad234-8b7a-47e8-ab86-0ebbc12a7ca7)
![image](https://github.com/user-attachments/assets/40c08bae-ff04-491a-b89c-4e6130110147)

Walbrook light+dark
![image](https://github.com/user-attachments/assets/87f30a4d-7dff-4e88-a24d-587889bedf9b)
![image](https://github.com/user-attachments/assets/8149c9aa-11ff-4443-a17f-294e2365bfec)

Technical Details
----------------------------------------
Changes RiverLea core, shouldn't impact streams.